### PR TITLE
Fix mime type database package name in docs

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -9,13 +9,13 @@ def locate_mime_database
     "/usr/share/mime/packages/freedesktop.org.xml"
   ].compact
   path = possible_paths.find { |candidate| File.exist?(candidate) }
-  
+
   return path unless path.nil?
   raise(<<~ERROR)
    Could not find MIME type database in the following locations: #{possible_paths}
-   
-   Ensure you have either installed the shared-mime-types package for your distribution, or 
-   obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location 
+
+   Ensure you have either installed the shared-mime-info package for your distribution, or
+   obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location
    of that file.
   ERROR
 end


### PR DESCRIPTION
Installing this gem on a system which does NOT contain the external
mime-type database fails indicating that the user should install the
shared-mime-types package.

```
Ensure you have either installed the shared-mime-types package for your distribution, or
obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location
of that file.
/usr/local/bundle/ruby/2.7.0/gems/mimemagic-0.3.7/ext/mimemagic/Rakefile:14:in `locate_mime_database'
/usr/local/bundle/ruby/2.7.0/gems/mimemagic-0.3.7/ext/mimemagic/Rakefile:25:in `block in <top (required)>'
/usr/local/bundle/ruby/2.7.0/gems/rake-13.0.3/exe/rake:27:in `<main>'
Tasks: TOP => default
(See full trace by running task with --trace)

rake failed, exit code 1

Gem files will remain installed in /usr/local/bundle/ruby/2.7.0/gems/mimemagic-0.3.7 for inspection.
Results logged to /usr/local/bundle/ruby/2.7.0/extensions/x86_64-linux/2.7.0/mimemagic-0.3.7/gem_make.out

An error occurred while installing mimemagic (0.3.7), and Bundler cannot continue.
Make sure that `gem install mimemagic -v '0.3.7' --source 'https://rubygems.org/'` succeeds before bundling.
```

Other places in the documentation this package is referred to as
`shared-mime-info`. This changes the error message to be consistent with
the documentation as to reduce confusion for the consumer.