### PR TITLE
[ex/mimemagic/Rakefile] Use older Ruby HEREDOC

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -11,7 +11,7 @@ def locate_mime_database
   path = possible_paths.find { |candidate| File.exist?(candidate) }
 
   return path unless path.nil?
-  raise(<<~ERROR)
+  raise(<<-ERROR.gsub(/^ {3}/, ""))
    Could not find MIME type database in the following locations: #{possible_paths}
 
    Ensure you have either installed the shared-mime-info package for your distribution, or


### PR DESCRIPTION
The "squiggly" heredoc was introduced in later versions of Ruby, so using a more compatible version of them with gsubing (to have the same effect) to allow this to build on more versions of Ruby.

Saw this on the Rails thread:

https://github.com/rails/rails/issues/41757#issuecomment-807289008

and I thought I would help address it.  Feel free to take this patch or do it in a different way if you would prefer a different solution.


Thanks for all the hard work the past 48ish hours!


Fixes #113


P.S.  I didn't address the "3 spaces" for the HEREDOC, since I didn't know if that was on purpose.  Can change if you would prefer.