### PR TITLE
fix: don't use squiggly heredoc in order to support Ruby versions < 2.3

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -9,13 +9,13 @@ def locate_mime_database
     "/usr/share/mime/packages/freedesktop.org.xml"
   ].compact
   path = possible_paths.find { |candidate| File.exist?(candidate) }
-  
+
   return path unless path.nil?
-  raise(<<~ERROR)
+  raise(<<-ERROR)
    Could not find MIME type database in the following locations: #{possible_paths}
-   
-   Ensure you have either installed the shared-mime-types package for your distribution, or 
-   obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location 
+
+   Ensure you have either installed the shared-mime-types package for your distribution, or
+   obtain a version of freedesktop.org.xml and set FREEDESKTOP_MIME_TYPES_PATH to the location
    of that file.
   ERROR
 end


### PR DESCRIPTION
Support for squiggly heredocs were added in Ruby 2.3. This change allows projects still running on older versions of Ruby (tested on 2.2.5) to install the library.

Ref: https://github.com/rails/rails/issues/41757#issuecomment-807289008

fixes #113 