### PR TITLE
Make Rake a runtime dependency

### DIFF
--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency('nokogiri', '~> 1')
+  s.add_dependency('rake')
 
   s.add_development_dependency('minitest', '~> 5.14')
-  s.add_development_dependency('rake', '~> 13.0')
 
   if s.respond_to?(:metadata)
     s.metadata['changelog_uri'] = "https://github.com/mimemagicrb/mimemagic/blob/master/CHANGELOG.md"


### PR DESCRIPTION
Fixes #119 

I opted not to specify a version constraint for Rake to avoid compatibility issues (I doubt that it's necessary).

Also, I targeted this PR at the `0.3` branch because we can't upgrade to 0.4, hope that's ok.