### PR TITLE
Add macports path for freedesktop.org.xml

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -6,6 +6,7 @@ def locate_mime_database
     (File.expand_path(ENV["FREEDESKTOP_MIME_TYPES_PATH"]) if ENV["FREEDESKTOP_MIME_TYPES_PATH"]),
     "/usr/local/share/mime/packages/freedesktop.org.xml",
     "/opt/homebrew/share/mime/packages/freedesktop.org.xml",
+    "/opt/local/share/mime/packages/freedesktop.org.xml",
     "/usr/share/mime/packages/freedesktop.org.xml"
   ].compact
   path = possible_paths.find { |candidate| File.exist?(candidate) }


### PR DESCRIPTION
During install, the freedesktop.org.xml  file is now found if installed via macports `shared-mime-info` port
mimemagicrb#123