### PR TITLE
Detect shared-mime-info being installed in mingw32/mingw64 environments

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -6,7 +6,9 @@ def locate_mime_database
     (File.expand_path(ENV["FREEDESKTOP_MIME_TYPES_PATH"]) if ENV["FREEDESKTOP_MIME_TYPES_PATH"]),
     "/usr/local/share/mime/packages/freedesktop.org.xml",
     "/opt/homebrew/share/mime/packages/freedesktop.org.xml",
-    "/usr/share/mime/packages/freedesktop.org.xml"
+    "/usr/share/mime/packages/freedesktop.org.xml",
+    "/mingw32/share/mime/packages/freedesktop.org.xml",
+    "/mingw64/share/mime/packages/freedesktop.org.xml"
   ].compact
   path = possible_paths.find { |candidate| File.exist?(candidate) }
 


### PR DESCRIPTION
Windows users can `pacman -S mingw-w64-x86_64-shared-mime-info` if they're running MSYS2 and then this gem will require no manual configuration. Should I add that to the README too?