### PR TITLE
Write path.rb to ext, not lib

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -23,7 +23,7 @@ end
 desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
-  open("../../lib/mimemagic/path.rb", "w") do |f|
+  open("path.rb", "w") do |f|
     f.print(%Q{
       class MimeMagic
         DATABASE_PATH="#{mime_database_path}"

--- a/mimemagic.gemspec
+++ b/mimemagic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email = ['mail@daniel-mendler.de', 'jon@blankpad.net']
 
   s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(test|script)/}) }
-  s.require_paths = %w(lib)
+  s.require_paths = %w(ext lib)
   s.extensions = %w(ext/mimemagic/Rakefile)
 
   s.summary = 'Fast mime detection by extension or content'


### PR DESCRIPTION
Fixes #121 

Bundler caches compiled extensions, so the file will not be generated when installing the extension from the cache, ~and it must be written to `ext` to be included in the cache~.