### PR TITLE
Write path.rb to Ruby arch dir so that it can be cached by Bundler

### DIFF
--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -23,7 +23,11 @@ end
 desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
-  open("../../lib/mimemagic/path.rb", "w") do |f|
+
+  target_dir = "#{ENV.fetch("RUBYARCHDIR")}/mimemagic"
+  mkdir_p target_dir
+
+  open("#{target_dir}/path.rb", "w") do |f|
     f.print(%Q{
       class MimeMagic
         DATABASE_PATH="#{mime_database_path}"


### PR DESCRIPTION
Fixes #121 

The `RUBYARCHDIR` environment variable is [set to the extension's destination directory in Rubygems' Rake builder](https://github.com/rubygems/rubygems/blob/5cfad4bd6661f2370bff0aaef1e81802420d2cef/lib/rubygems/ext/rake_builder.rb#L28), and this is the directory that Bundler copies into the extension cache.

This directory is also added to the load path by Rubygems, so that `require "mimemagic/path"` still finds it correctly.

With this change, the generated `path.rb` is present in the extension cache, so both fresh installs and subsequent reinstalls now work.