### PR TITLE
fixes gem development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 *.gem
 Gemfile.lock
 .bundle
+
+# doc
 .yardoc
+doc/
+
 vendor
+
+# don't include generated files
 lib/mimemagic/path.rb

--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,6 @@
+--markup-provider=redcarpet
+--markup=markdown
 --no-private
 - README.md
+- LICENSE
+- CHANGELOG.md

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org/'
 gemspec
 
+gem 'yard'
+gem 'redcarpet'
+gem 'github-markup'

--- a/README.md
+++ b/README.md
@@ -48,9 +48,6 @@ Tests
 
 ```console
 $ bundle install
-$ cd ext/mimemagic/
-$ bundle exec rake
-$ popd
 
 $ bundle exec rake test
 ```
@@ -65,4 +62,4 @@ Authors
 LICENSE
 =======
 
-MIT
+{file:LICENSE MIT}

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,15 @@
 require 'rake/testtask'
+require 'rake/clean'
+
+namespace :ext do
+  load 'ext/mimemagic/Rakefile'
+end
+CLOBBER.include("lib/mimemagic/path.rb")
 
 task :default => %w(test)
 
 desc 'Run tests with minitest'
-Rake::TestTask.new do |t|
+Rake::TestTask.new("test" => "ext:default") do |t|
   t.libs << 'test'
   t.pattern = 'test/*_test.rb'
 end

--- a/ext/mimemagic/Rakefile
+++ b/ext/mimemagic/Rakefile
@@ -23,11 +23,13 @@ end
 desc "Build a file pointing at the database"
 task :default do
   mime_database_path = locate_mime_database
-  open("../../lib/mimemagic/path.rb", "w") do |f|
-    f.print(%Q{
+  path_rb = File.expand_path("../../../lib/mimemagic/path.rb", __FILE__)
+  open(path_rb, "w") do |f|
+    f.print(<<~SOURCE
       class MimeMagic
         DATABASE_PATH="#{mime_database_path}"
       end
-    })
+      SOURCE
+    )
   end
 end


### PR DESCRIPTION
- load and namespace the ext/mimemagic/Rakefile into the main Rakefile
- update test task to include ext as a prereq
- add the generated path.rb to clobber

These two changes are to ext/mimemagic/Rakefile, so not just dev env.
- use more robust file path (gem dev vs install time path consistency)
- use squiggly HEREDOC to indent generated file properly

update the README to match
add LICENSE to doc
add CHANGELOG.md to doc

add yardoc settings for doc writers

fixes #137 